### PR TITLE
Add concurrency controls

### DIFF
--- a/valarie/executor/procedure.py
+++ b/valarie/executor/procedure.py
@@ -77,7 +77,7 @@ def get_queued_hosts(prcuuid):
     job_lock.acquire()
     
     for jobuuid, dict in jobs.items():
-        if prcuuid == dict["host"]["objuuid"]:
+        if prcuuid == dict["procedure"]["objuuid"]:
             hstuuids.append(dict["host"]["objuuid"])
 
     job_lock.release()

--- a/valarie/executor/procedure.py
+++ b/valarie/executor/procedure.py
@@ -77,7 +77,7 @@ def get_queued_hosts(prcuuid):
     job_lock.acquire()
     
     for jobuuid, dict in jobs.items():
-        if prcuuid == dict["procedure"]["objuuid"]:
+        if prcuuid == dict["procedure"]["objuuid"] and dict["process"] is None:
             hstuuids.append(dict["host"]["objuuid"])
 
     job_lock.release()
@@ -470,14 +470,12 @@ def worker():
                 assert int(jobs[key]["host"]["concurrency"]) > 0
             except:
                 add_message("invalid host concurrency\n{0}".format(traceback.format_exc()))
-                add_message(json.dumps(jobs[key]["host"], indent=4))
                 jobs[key]["host"]["concurrency"] = "1"
             
             try:
                 assert int(jobs[key]["console"]["concurrency"]) > 0
             except:
                 add_message("invalid console concurrency\n{0}".format(traceback.format_exc()))
-                add_message(json.dumps(jobs[key]["console"], indent=4))
                 jobs[key]["console"]["concurrency"] = "1"
 
         running_jobs_counts = {}

--- a/valarie/executor/procedure.py
+++ b/valarie/executor/procedure.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
 MAX_JOBS = 20
-MAX_JOBS_PER_HOST = 2
 
 import traceback
 

--- a/valarie/executor/procedure.py
+++ b/valarie/executor/procedure.py
@@ -3,7 +3,6 @@
 MAX_JOBS = 20
 
 import traceback
-import json
 
 from threading import Lock, Thread, Timer
 from time import time

--- a/valarie/model/console.py
+++ b/valarie/model/console.py
@@ -48,6 +48,7 @@ def create_console(parent_objuuid, name = "New Console", objuuid = None):
         "name" : name,
         "body" : CONSOLE_PROTO_BODY,
         "icon" : "/images/console_icon.png",
+        "concurrency" : 1,
         "context" : {
             "delete" : {
                 "label" : "Delete",

--- a/valarie/model/host.py
+++ b/valarie/model/host.py
@@ -15,6 +15,8 @@ def create_host(parent_objuuid, name = "New Host", objuuid = None):
         "host" : "",
         "icon" : "/images/host_icon.png",
         "console" : None,
+        "concurrency" : 1,
+        "config" : "",
         "context" : {
             "delete" : {
                 "label" : "Delete",

--- a/valarie/static/js/console.js
+++ b/valarie/static/js/console.js
@@ -5,6 +5,7 @@ var editConsole = function() {
     initAttributes();
     addAttributeText('Console UUID', 'objuuid');
     addAttributeTextBox('Console Name', 'name');
+    addAttributeTextBox('Max Concurrency', 'concurrency');
 
     var editor = new ace.edit(document.getElementById('aceInstance'));
     

--- a/valarie/static/js/host.js
+++ b/valarie/static/js/host.js
@@ -71,6 +71,8 @@ var launchTerminal = function() {
     addAttributeText('Host UUID', 'objuuid');
     addAttributeTextBox('Name', 'name');
     addAttributeTextBox('Host', 'host');
+    addAttributeTextBox('Max Concurrency', 'concurrency');
+    addAttributeTextArea('Configuration', 'config');
     
     $.ajax({
         'url' : 'console/ajax_get_consoles',

--- a/valarie/static/js/host.js
+++ b/valarie/static/js/host.js
@@ -17,6 +17,8 @@ var editHost = function() {
     addAttributeText('Host UUID', 'objuuid');
     addAttributeTextBox('Name', 'name');
     addAttributeTextBox('Host', 'host');
+    addAttributeTextBox('Max Concurrency', 'concurrency');
+    addAttributeTextArea('Configuration', 'config');
     
     $.ajax({
         'url' : 'console/ajax_get_consoles',


### PR DESCRIPTION
Added concurrency controls to hosts and consoles. This means there is a host, console, as well as global concurrency limit. The lowest limit value from these three is used as the winning limit by the job queuing mechanism in the executor.